### PR TITLE
user misconfigurations in soda checks are masked

### DIFF
--- a/run.py
+++ b/run.py
@@ -29,8 +29,11 @@ class NadaSoda:
             if f.endswith(".yaml"):
                 gcp_project, dataset, scan = self._run_scan(f)
                 logging.info(f"Scan {f} finished")
-                self._publish_results(gcp_project, dataset, scan)
-                logging.info(f"Successfully published results from scan {f}")
+                if not scan.has_error_logs():
+                    self._publish_results(gcp_project, dataset, scan)
+                    logging.info(f"Successfully published results from scan {f}")
+                else:
+                    logging.error(f"Not publishing results due to scan errors. Errors for scan {f}:\n{scan.get_error_logs_text()}")
 
     def _run_scan(self, f: str) -> tuple[str, str, Scan]:
         s = Scan()


### PR DESCRIPTION
User misconfigurations for scans are not reported to the user and results are published regardless. With the latest option to send slack notifications on passed soda checks we will mask a potential configuration error, e.g. a check referrering to a nonexisting column in a table.

Proposing with this PR to log error and not publish the scan results if the user has misconfigurations leading to query execution errors.